### PR TITLE
Initial Release - v1.1.1

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
+    'sphinx_markdown_tables',
     'recommonmark',
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive'
@@ -39,6 +40,7 @@ autodoc_default_options = {
     'undoc-members': True,
     'exclude-members': '__weakref__'
 }
+
 # autodoc_type_aliases = {
 #     'RedisType': 'redisent.common.RedisType',
 #     'RedisPoolType': 'redisent.common.RedisPoolType'
@@ -59,6 +61,10 @@ for name in dir(builtins):
 
 for cls_name in nitpick_classes:
     nitpick_ignore.append(('py:class', cls_name))
+
+source_parsers = {
+    '.md': 'recommonmark.parser.CommonMarkParser',
+}
 
 source_suffix = {
     '.rst': 'restructuredtext',

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx
 sphinx-autodoc-typehints
 sphinx_rtd_theme
+sphinx-markdown-tables
 recommonmark

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setuptools.setup(
     package_dir={'': 'src'},
     packages=setuptools.find_packages(where='src'),
     python_requires='>=3.8',
-    zip_safe=False,
     extras_require={
         'dev': ['IPython', 'jupyterlab'],
         'test': test_requirements,

--- a/src/redisent/__init__.py
+++ b/src/redisent/__init__.py
@@ -11,7 +11,7 @@ from redisent.common import RedisPrimitiveType, RedisType, RedisPoolType
 root_logger = logging.getLogger(__name__)
 log_ch = logging.StreamHandler()
 
-__version__ = '1.0.5'
+__version__ = '1.1.1'
 LOG_LEVEL = logging.DEBUG if os.environ.get('REDISENT_DEBUG', False) else logging.CRITICAL
 
 


### PR DESCRIPTION
This is the first (real) PR for this repository and is also tagged `v1.1.1`

Build passed locally with `tox`, `mypy` and `flake8` testing but more coverage is needed in the upcoming releases as well as more documentation and some different examples.

After merging this, the new [minder Discord bot](https://github.com/synistree/minder) will also be released which makes more extensive use of this library.
